### PR TITLE
fix: setState queue logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/store",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "基于 React Hooks 的数据流方案",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/store.ts
+++ b/src/store.ts
@@ -40,20 +40,18 @@ export default class Store {
 
     private setState(newState: object): void {
         this.state = newState;
-        const queue = [].concat(this.queue);
-        this.queue = [];
-        queue.forEach(setState => setState(newState));
+        this.queue.forEach(setState => setState(newState));
     }
 
     public useStore(): object {
-        const [, setState] = useState();
+        const [, setState] = useState(this.state);
         useEffect(() => {
             const index = this.queue.length;
             this.queue.push(setState);
             return () => {
                 this.queue.splice(index, 1);
             };
-        });
+        }, []);
 
         return this.getBindings();
     }


### PR DESCRIPTION
问题：现有逻辑是每次rerender都重新将setState加入队列，然后action执行完再重新再将setState从队列中移除，以下case有可能有bug：
依次执行了两个异步action，第一个action执行完，将setState中从队列中移除了，并且触发页面rerender，但是当页面rerender时间比较长时，这时当第二个action执行时机在页面rerender之前，将会导致队列中还没来得及将新的setState加入队列，此时this.queue为空，将会导致action执行完不会rerender。

```javascript
const queue = [].concat(this.queue);	// 第一个action触发的rerender还未执行完，this.queue中仍然为空
this.queue = [];	
queue.forEach(setState => setState(newState));	 // setState不会触发

```

fix: 只在didMount时将setState push入队列，unmount时从队列中pop出来，每次rerender不重新操作队列，action执行完每次都是访问相同的队列