### PR TITLE
fix: incorrect setState splice logic when unmount

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/store",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "基于 React Hooks 的数据流方案",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/store.ts
+++ b/src/store.ts
@@ -46,9 +46,9 @@ export default class Store {
     public useStore(): object {
         const [, setState] = useState(this.state);
         useEffect(() => {
-            const index = this.queue.length;
             this.queue.push(setState);
             return () => {
+                const index = this.queue.indexOf(setState);
                 this.queue.splice(index, 1);
             };
         }, []);


### PR DESCRIPTION
现象：参考此关联[issue](https://github.com/alibaba/ice/issues/2245)， iceworks中项目与工程Tab切换时也可以复现此warning。

问题: unmount时必须将使用useStore组件的setState从队列中移除以防止已经unmount的组件再次被刷新 ，源码中该处的处理逻辑如下：

```javascript
         useEffect(() => {
             const index = this.queue.length;
             this.queue.push(setState);
             return () => {
                 this.queue.splice(index, 1);
             };
         }, []);
```
该逻辑有两个问题：
1. splice的index取数组长度不对，例如 queue = ['a', 'b']; queue.splice(2, 1); 结果queue还是['a', 'b']
2. 总是取最后一个unmount，会导致queue中有多个setState时，无法保证splice的顺序，例如queue中依次push了a，b，c三个setState，但是unmout时只需要移除b，此时splice最后一个将导致错误移除了c。

fix: unmount时查询当前组件的setState在queue中的index，再使用该index进行splice