### PR TITLE
Refactor: bindings & performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/store",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "基于 React Hooks 的数据流方案",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "typescript": "^3.4.4"
   },
   "dependencies": {
-    "lodash.isfunction": "^3.0.9"
+    "lodash.isfunction": "^3.0.9",
+    "lodash.isobject": "^3.0.2"
   },
   "peerDependencies": {
     "react": "^16.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/store",
-  "version": "0.2.0",
+  "version": "0.1.5",
   "description": "基于 React Hooks 的数据流方案",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/store.ts
+++ b/src/store.ts
@@ -29,7 +29,7 @@ export default class Store {
       set: (target, prop, value) => {
         if (!this.allowMutate) {
           console.error('Forbid modifying state directly, use action to modify instead.');
-          return true;
+          return false;
         }
         if (target[prop] !== value) {
           this.stateChanged = true;

--- a/src/store.ts
+++ b/src/store.ts
@@ -30,6 +30,7 @@ export default class Store {
       set: (target, prop, value) => {
         if (!this.allowMutate) {
           console.error('Forbid modifying state directly, use action to modify instead.');
+          return true;
         }
         if (target[prop] !== value) {
           this.stateChanged = true;

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,50 +1,97 @@
-
 import * as isFunction from 'lodash.isfunction';
 import { useState, useEffect } from 'react';
+import { addProxy } from './util';
 
 interface MethodFunc {
   (): void;
 }
 
 export default class Store {
-  private state: {[name: string]: any} = {};
 
-  private methods: {[name: string]: MethodFunc} = {};
+  // store state and actions user defined
+  private bindings: {[name: string]: any} = {};
 
+  // queue of setState method from useState hook
   private queue = [];
+
+  // flag of whether allow state mutate
+  private allowMutate = false;
+
+  // flag of whether state changed after mutation
+  private stateChanged = false;
 
   public constructor(bindings: object) {
     Object.keys(bindings).forEach((key) => {
       const value = bindings[key];
-
-      if (isFunction(value)) {
-        this.methods[key] = this.createMethod(value);
-      } else {
-        this.state[key] = value;
-      }
+      this.bindings[key] = isFunction(value) ? this.createAction(value) : value;
     });
+
+    const handler = {
+      set: (target, prop, value) => {
+        if (!this.allowMutate) {
+          console.error('Forbid modifying state directly, use action to modify instead.');
+        }
+        if (target[prop] !== value) {
+          this.stateChanged = true;
+        }
+        target[prop] = addProxy(value, handler);
+        return true;
+      },
+    };
+
+    this.bindings = addProxy(this.bindings, handler);
   }
 
-  private getBindings() {
-    return { ...this.state, ...this.methods };
-  }
-
-  private createMethod(fun): MethodFunc {
+  /**
+   * Create action which will trigger state update after mutation
+   * @param {func} fun - original method user defined
+   * @return {func} action function
+   */
+  private createAction(fun): MethodFunc {
     return async (...args) => {
-      const newState = { ...this.state };
-      await fun.apply(newState, args);
-      this.setState(newState);
-      return this.getBindings();
+      this.allowMutate = true;
+      await fun.apply(this.bindings, args);
+      if (this.stateChanged) {
+        this.setState();
+      }
+      this.allowMutate = false;
+      this.stateChanged = false;
+      return this.bindings;
     };
   }
 
-  private setState(newState: object): void {
-    this.state = newState;
+  /**
+   * Get state from bindings
+   * @return {object} state
+   */
+  private getState(): object {
+    const { bindings } = this;
+    const state = {};
+    Object.keys(bindings).forEach((key) => {
+      const value = bindings[key];
+      if (!isFunction(value)) {
+        state[key] = value;
+      }
+    });
+    return state;
+  }
+
+  /**
+   * Trigger setState method in queue
+   */
+  private setState(): void {
+    const state = this.getState();
+    const newState = { ...state };
     this.queue.forEach(setState => setState(newState));
   }
 
+  /**
+   * Hook used to register setState and expose bindings
+   * @return {object} bindings of store
+   */
   public useStore(): object {
-    const [, setState] = useState(this.state);
+    const state = this.getState();
+    const [, setState] = useState(state);
     useEffect(() => {
       this.queue.push(setState);
       return () => {
@@ -52,7 +99,6 @@ export default class Store {
         this.queue.splice(index, 1);
       };
     }, []);
-
-    return this.getBindings();
+    return this.bindings;
   }
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,3 +1,5 @@
+/* eslint no-param-reassign: 0 */
+
 import * as isFunction from 'lodash.isfunction';
 import { useState, useEffect } from 'react';
 import { addProxy } from './util';
@@ -7,7 +9,6 @@ interface MethodFunc {
 }
 
 export default class Store {
-
   // store state and actions user defined
   private bindings: {[name: string]: any} = {};
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,3 @@
-/* eslint no-param-reassign: 0 */
-
 import * as isFunction from 'lodash.isfunction';
 import { useState, useEffect } from 'react';
 import { addProxy } from './util';
@@ -36,6 +34,7 @@ export default class Store {
         if (target[prop] !== value) {
           this.stateChanged = true;
         }
+        /* eslint no-param-reassign: 0 */
         target[prop] = addProxy(value, handler);
         return true;
       },

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,9 @@
+/* eslint no-param-reassign: 0, import/prefer-default-export: 0 */
+
 import * as isObject from 'lodash.isobject';
 import * as isFunction from 'lodash.isfunction';
 
-const isArray = Array.isArray;
+const { isArray } = Array;
 
 /**
  * Recursively add proxy to javascipt variable

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,9 +10,9 @@ const { isArray } = Array;
  * @return {object} new proxy object
  */
 /* eslint no-param-reassign: 0, import/prefer-default-export: 0 */
-export function addProxy(value: any, handler: object): any {
-  // primitive type (number, boolean, string, null, undefined) and function type
-  if (!isObject(value) || isFunction(value)) {
+export function addProxy(value: object, handler: object): any {
+  // null and function also belongs to object type
+  if (value === null || isFunction(value)) {
     return value;
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,3 @@
-/* eslint no-param-reassign: 0, import/prefer-default-export: 0 */
-
 import * as isObject from 'lodash.isobject';
 import * as isFunction from 'lodash.isfunction';
 
@@ -11,6 +9,7 @@ const { isArray } = Array;
  * @param {func} handler - proxy handler
  * @return {object} new proxy object
  */
+/* eslint no-param-reassign: 0, import/prefer-default-export: 0 */
 export const addProxy = (value, handler) => {
   if (!isObject(value) || isFunction(value)) {
     return value;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,31 @@
+import * as isObject from 'lodash.isobject';
+import * as isFunction from 'lodash.isfunction';
+
+const isArray = Array.isArray;
+
+/**
+ * Recursively add proxy to javascipt variable
+ * @param {*} value - javascript variable of any type
+ * @param {func} handler - proxy handler
+ * @return {object} new proxy object
+ */
+export const addProxy = (value, handler) => {
+  if (!isObject(value) || isFunction(value)) {
+    return value;
+  }
+
+  if (isArray(value)) {
+    value.forEach((item, index) => {
+      if (isObject(item)) {
+        value[index] = addProxy(item, handler);
+      }
+    });
+  } else if (isObject(value)) {
+    Object.keys(value).forEach((key) => {
+      if (isObject(value[key])) {
+        value[key] = addProxy(value[key], handler);
+      }
+    });
+  }
+  return new Proxy(value, handler);
+};

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,7 +11,7 @@ const { isArray } = Array;
  */
 /* eslint no-param-reassign: 0, import/prefer-default-export: 0 */
 export function addProxy(value: any, handler: object): any {
-  // basic type (number, boolean, string, null, undefined) and function type
+  // primitive type (number, boolean, string, null, undefined) and function type
   if (!isObject(value) || isFunction(value)) {
     return value;
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,9 +10,9 @@ const { isArray } = Array;
  * @return {object} new proxy object
  */
 /* eslint no-param-reassign: 0, import/prefer-default-export: 0 */
-export function addProxy(value: object, handler: object): any {
-  // null and function also belongs to object type
-  if (value === null || isFunction(value)) {
+export function addProxy(value: any, handler: object): any {
+  // primitive type (number, boolean, string, null, undefined) and function type
+  if (!isObject(value) || isFunction(value)) {
     return value;
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,29 +4,30 @@ import * as isFunction from 'lodash.isfunction';
 const { isArray } = Array;
 
 /**
- * Recursively add proxy to javascipt variable
- * @param {*} value - javascript variable of any type
- * @param {func} handler - proxy handler
+ * Recursively add proxy to object and array
+ * @param {*} value - variable of any type
+ * @param {object} handler - proxy handler
  * @return {object} new proxy object
  */
 /* eslint no-param-reassign: 0, import/prefer-default-export: 0 */
-export const addProxy = (value, handler) => {
+export function addProxy(value: any, handler: object): any {
+  // basic type (number, boolean, string, null, undefined) and function type
   if (!isObject(value) || isFunction(value)) {
     return value;
   }
 
-  if (isArray(value)) {
+  if (isArray(value)) { // array type
     value.forEach((item, index) => {
-      if (isObject(item)) {
+      if (isObject(item)) { // object and array type
         value[index] = addProxy(item, handler);
       }
     });
-  } else if (isObject(value)) {
+  } else if (isObject(value)) { // object type
     Object.keys(value).forEach((key) => {
-      if (isObject(value[key])) {
+      if (isObject(value[key])) { // object and array type
         value[key] = addProxy(value[key], handler);
       }
     });
   }
   return new Proxy(value, handler);
-};
+}

--- a/tests/util.spec.tsx
+++ b/tests/util.spec.tsx
@@ -1,0 +1,85 @@
+import { addProxy } from '../src/util';
+
+describe('#util', () => {
+  let handler;
+
+  beforeEach(() => {
+    handler = {
+      set: (target, prop): boolean => {
+        /* eslint no-param-reassign: 0 */
+        target[prop] = 'foo';
+        return true;
+      },
+    };
+  });
+
+  describe('#addProxy', () => {
+    test('should boolean type not affected', () => {
+      const value = false;
+      expect(addProxy(value, handler)).toBe(value);
+    });
+
+    test('should number type not affected', () => {
+      const value = 1;
+      expect(addProxy(value, handler)).toBe(value);
+    });
+
+    test('should string type not affected', () => {
+      const value = 'abc';
+      expect(addProxy(value, handler)).toBe(value);
+    });
+
+    test('should null type not affected', () => {
+      const value = null;
+      expect(addProxy(value, handler)).toBe(value);
+    });
+
+    test('should undefined type not affected', () => {
+      const value = undefined;
+      expect(addProxy(value, handler)).toBe(value);
+    });
+
+    test('should function type not affected', () => {
+      const value = () => {};
+      expect(addProxy(value, handler)).toBe(value);
+    });
+
+    test('should object proxy set success', () => {
+      const value = {
+        a: 1,
+        b: 2,
+      };
+      const result = addProxy(value, handler);
+      result.a = 100;
+      expect(result.a).toBe('foo');
+    });
+
+    test('should object proxy recursively set success', () => {
+      const value = {
+        a: [
+          { c: 3 },
+        ],
+        b: 2,
+      };
+      const result = addProxy(value, handler);
+      result.a[0].c = 4;
+      expect(result.a[0].c).toBe('foo');
+    });
+
+    test('should array proxy set success', () => {
+      const value = [1, 2];
+      const result = addProxy(value, handler);
+      result[0] = 4;
+      expect(result[0]).toBe('foo');
+    });
+
+    test('should array proxy recursively set success', () => {
+      const value = [
+        { a: 1 },
+      ];
+      const result = addProxy(value, handler);
+      result[0].a = 4;
+      expect(result[0].a).toBe('foo');
+    });
+  });
+});

--- a/tests/util.spec.tsx
+++ b/tests/util.spec.tsx
@@ -14,6 +14,31 @@ describe('#util', () => {
   });
 
   describe('#addProxy', () => {
+    test('should boolean type not affected', () => {
+      const value = false;
+      expect(addProxy(value, handler)).toBe(value);
+    });
+
+    test('should number type not affected', () => {
+      const value = 1;
+      expect(addProxy(value, handler)).toBe(value);
+    });
+
+    test('should string type not affected', () => {
+      const value = 'abc';
+      expect(addProxy(value, handler)).toBe(value);
+    });
+
+    test('should null type not affected', () => {
+      const value = null;
+      expect(addProxy(value, handler)).toBe(value);
+    });
+
+    test('should undefined type not affected', () => {
+      const value = undefined;
+      expect(addProxy(value, handler)).toBe(value);
+    });
+
     test('should function type not affected', () => {
       const value = () => {};
       expect(addProxy(value, handler)).toBe(value);

--- a/tests/util.spec.tsx
+++ b/tests/util.spec.tsx
@@ -14,31 +14,6 @@ describe('#util', () => {
   });
 
   describe('#addProxy', () => {
-    test('should boolean type not affected', () => {
-      const value = false;
-      expect(addProxy(value, handler)).toBe(value);
-    });
-
-    test('should number type not affected', () => {
-      const value = 1;
-      expect(addProxy(value, handler)).toBe(value);
-    });
-
-    test('should string type not affected', () => {
-      const value = 'abc';
-      expect(addProxy(value, handler)).toBe(value);
-    });
-
-    test('should null type not affected', () => {
-      const value = null;
-      expect(addProxy(value, handler)).toBe(value);
-    });
-
-    test('should undefined type not affected', () => {
-      const value = undefined;
-      expect(addProxy(value, handler)).toBe(value);
-    });
-
     test('should function type not affected', () => {
       const value = () => {};
       expect(addProxy(value, handler)).toBe(value);


### PR DESCRIPTION
该PR重构包含以下两个问题的解决方案：

问题一：状态同步方式
目前icestore状态同步方式必须等setState后再同步，不直观且易引起bug，详细参考此[issue](https://github.com/alibaba/ice/issues/2299)

解决方案：
1. store实例上定义bindings属性，包含state与methods，useStore与action执行完返回此bindings引用，因此action执行完能从store实例上实时拿到更新值
2. 防止用户直接改变store上的state方案如下：
    1.  对于bindings递归包Proxy，在store实例上定义允许改变值的flag allowMutate，默认为false
    2. 对于bindings中每个state递归包Proxy, Proxy的set handler中通过allowMuate判断是否允许修改state
    3. 当调用action时allowMuate设为true，允许修改，如果在action之外修改，不允许修改并报错提示用户

问题二：性能问题
action调用后并未判断值是否真实发生变化，可能会引起不必要的rerender

解决方案：
1. store实例上定义stateChanged flag，标识state是否发生变化 
2. 在Proxy中set handler设置值时进行浅比较（是否有必要进行deep-diff？性能可能有损耗）判断值是否发生变化，如果已变化，则触发队列的setState，否则不触发。 

