### PR TITLE
fix: freeze object (eg. react element) add proxy error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/store",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "基于 React Hooks 的数据流方案",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,10 +9,13 @@ import * as forEach from 'lodash.foreach';
  */
 /* eslint no-param-reassign: 0, import/prefer-default-export: 0 */
 export function addProxy(value: object, handler: object): object {
+  if (!value || Object.isFrozen(value)) {
+    return value;
+  }
   forEach(value, (item, key) => {
     if (isObject(item)) {
       value[key] = addProxy(item, handler);
     }
   });
-  return value && new Proxy(value, handler);
+  return new Proxy(value, handler);
 }

--- a/tests/util.spec.tsx
+++ b/tests/util.spec.tsx
@@ -19,6 +19,14 @@ describe('#util', () => {
       expect(addProxy(value, handler)).toBe(value);
     });
 
+    test('should frozen object not affected', () => {
+      const value = Object.freeze({
+        a: 1,
+        b: 2,
+      });
+      expect(addProxy(value, handler)).toBe(value);
+    });
+
     test('should function proxy set success', () => {
       const value = () => {};
       const result: any = addProxy(value, handler);


### PR DESCRIPTION
现象：state中存储了React element，在action改变state时报错，而由于React element自身是freeze状态，store中对对象递归设proxy时报不能修改只读对象的属性的错误。

fix: 包proxy时判断对象是否frozen，如果是直接返回自身
