### PR TITLE
feat: add toJS util

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,34 @@ Hook to use a single store.
 * Return value
   - {object} single store instance
 
+### toJS
+
+Recursively convert proxified state object to plain javaScript type.
+
+* Parameters
+  - value {any} value of any javaScript type
+* Return value
+  - {any} javaScript value of any type
+
+#### Example
+
+```javascript
+// store.js
+export default {
+  value: {
+    a: 1,
+    b: 2,
+  }
+};
+
+// view.jsx
+import IceStore, { toJS } from '@ice/store';
+const { value } = useStore('foo');
+
+const a = toJS(value);
+console.log(a);
+
+```
 ## Advanced use
 
 ### async actions' executing status

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -192,6 +192,35 @@ ReactDOM.render(<Todo />, rootElement);
 * 返回值
   - {object} store 的配置对象
 
+### toJS
+
+递归将 Proxy 化的 state 对象转化成普通的 javaScript 对象
+
+* 参数
+  - value {any} 任意 javaScript 类型值
+* 返回值
+  - {any} 去 Proxy 后的 javaScript 类型
+
+#### 示例
+
+```javascript
+// store.js
+export default {
+  value: {
+    a: 1,
+    b: 2,
+  }
+};
+
+// view.jsx
+import IceStore, { toJS } from '@ice/store';
+const { value } = useStore('foo');
+
+const a = toJS(value);
+console.log(a);
+
+```
+
 ## 高级用法
 
 ### 异步 action 执行状态

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/store",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Lightweight React state management library based on react hooks",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import Store from './store';
+import { toJS } from './util';
 
 export default class Icestore {
   /** Stores registered */
@@ -50,3 +51,5 @@ export default class Icestore {
     return namespaces.map(namespace => this.useStore(namespace));
   }
 }
+
+export { toJS };

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,7 +7,7 @@ import * as forEach from 'lodash.foreach';
  * @param {object} handler - proxy handler
  * @return {object} new proxy object
  */
-/* eslint no-param-reassign: 0, import/prefer-default-export: 0 */
+/* eslint no-param-reassign: 0 */
 export function addProxy(value: object, handler: object): object {
   if (!value || Object.isFrozen(value)) {
     return value;
@@ -18,4 +18,25 @@ export function addProxy(value: object, handler: object): object {
     }
   });
   return new Proxy(value, handler);
+}
+
+/**
+ * Convert proxied value to plain js object
+ * @param {any} value - js value of any type
+ * @return {any} plain js type
+ */
+export function toJS(value: any): any {
+  if (!value || !isObject(value)) {
+    return value;
+  }
+
+  const newValue = Array.isArray(value) ? [] : {};
+  forEach(value, (item, key) => {
+    if (isObject(item)) {
+      newValue[key] = toJS(item);
+    } else {
+      newValue[key] = item;
+    }
+  });
+  return newValue;
 }

--- a/tests/util.spec.tsx
+++ b/tests/util.spec.tsx
@@ -1,4 +1,4 @@
-import { addProxy } from '../src/util';
+import { addProxy, toJS } from '../src/util';
 
 describe('#util', () => {
   let handler;
@@ -70,6 +70,33 @@ describe('#util', () => {
       const result: any = addProxy(value, handler);
       result[0].a = 4;
       expect(result[0].a).toBe('foo');
+    });
+  });
+
+
+  describe('#toJS', () => {
+    test('should null type convert success', () => {
+      const value = null;
+      const jsValue = toJS(value);
+      expect(jsValue).toBe(value);
+    });
+
+    test('should non object type convert success', () => {
+      const value = 1;
+      const jsValue = toJS(value);
+      expect(jsValue).toBe(value);
+    });
+
+    test('should object type convert success', () => {
+      const value = {
+        a: [
+          { c: 3 },
+        ],
+        b: 2,
+      };
+      const result: any = addProxy(value, handler);
+      const jsValue = toJS(result);
+      expect(jsValue).toEqual(value);
     });
   });
 });


### PR DESCRIPTION
## 背景

目前 icestore 内部会将所有 state 包一层 Proxy，因此从 useStore 中拿到的对象类型的 state 实际上是 Proxy 化的值，带来两个问题：
1. 不方便调试，console 出来是 Proxy 化的对象，无法方便查看原始的 js 对象
2. 业务中有需要拿到 state 原始的 js 的场景，例如表单的 value 需要存储在 store 中的场景，一旦存储到 store 中 value 就 Proxy 化了，从 useStore 中获取的 value 无法直接作为 props 挂在 Form 上

## 方案
全局加上 toJS 方法（方法名参考 immuntableJS 与 mobx），传入任意 state 值，返回去 Proxy 化的值
使用方式:

```javascript

// store.js
export default {
  value: {
    a: 1,
    b: 2,
  }
};

// view.jsx
import IceStore, { toJS } from '@ice/store';
const { value } = useStore('foo');

const a = toJS(value);
```
