### PR TITLE
Updated react version and modified .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ typings/
 lib
 
 package-lock.json
+
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "lodash.isobject": "^3.0.2"
   },
   "peerDependencies": {
-    "react": "^16.7.0"
+    "react": "^16.8.0"
   },
   "jest": {
     "coverageDirectory": "./coverage/",


### PR DESCRIPTION
主要修改了 2 个点

1. 升级了一下 peerDependencies 中 react 依赖的版本  
2. 将  yarn.lock 添加进 `.gitignore` 文件（PS： 这个地方可能有些争议，我个人喜欢用 yarn 来管理依赖包，并且觉得应该将 lock 文件放在版本管理库中，但看到作者将 package.lock 放在了 `.gitignore` 中，故也将 yarn.lock 放在了 `.gitignore` 中） 