### PR TITLE
feature: immer for reducers

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -377,6 +377,8 @@ const count = {
 }
 ```
 
+See [docs/recipes](./recipes.md#immutable-description) for more details.
+
 ##### effects
 
 `effects: { [string]: (prevState, payload, actions, globalActions) => void }`

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -326,6 +326,59 @@ ReactDOM.render(<Provider>
 </Provider>, document.getElementById('root'));
 ```
 
+## Immutable Description 
+
+### Don't destructure the state argument
+
+In order to support the mutation API we utilise [immer](https://github.com/immerjs/immer). Under the hood immer utilises Proxies in order to track our mutations, converting them into immutable updates. Therefore if you destructure the state that is provided to your action you break out of the Proxy, after which any update you perform to the state will not be applied.
+
+Below are a couple examples of this antipattern.
+
+```js
+const model = {
+  reducers: {
+    addTodo({ items }, payload) {
+      items.push(payload);
+    },
+
+    // or 
+
+    addTodo(state, payload) => {
+      const { items } = state;
+      items.push(payload);
+    }
+  }
+}
+```
+
+### Switching to an immutable API
+
+By default we use immer to provide a mutation based API.
+
+This is completely optional, you can instead return new state from your actions like below.
+
+```js
+const model = {
+  state: [],
+  reducers: {
+    addTodo((prevState, payload) {
+      // 👇 new immutable state returned
+      return [...prevState, payload];
+    })
+  }
+}
+```
+
+Should you prefer this approach you can explicitly disable immer via the disableImmer option value of createStore.
+
+```js
+import { createStore } from '@ice/store';
+
+const store = createStore(models, {
+  disableImmer: true; // 👈 set the flag
+});
+```
+
 ## Comparison
 
 - O: Yes

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -233,10 +233,7 @@ const todos = {
   },
   reducers: {
     update(prevState, payload) {
-      return {
-        ...prevState,
-        ...payload,
-      };
+      return { ...prevState, ...payload };
     },
   },
   effects: {

--- a/examples/todos/src/models/todos.ts
+++ b/examples/todos/src/models/todos.ts
@@ -20,12 +20,7 @@ const todos = {
   },
   reducers: {
     toggle(prevState: TodosState, index: number) {
-      const dataSource = [].concat(prevState.dataSource);
-      dataSource[index].done = !prevState.dataSource[index].done;
-      return {
-        ...prevState,
-        dataSource,
-      };
+      prevState.dataSource[index].done = !prevState.dataSource[index].done;
     },
     update(prevState: TodosState, payload) {
       return {

--- a/examples/todos/src/models/todos.ts
+++ b/examples/todos/src/models/todos.ts
@@ -19,8 +19,8 @@ const todos = {
     ],
   },
   reducers: {
-    toggle(prevState: TodosState, index: number) {
-      prevState.dataSource[index].done = !prevState.dataSource[index].done;
+    toggle(state: TodosState, index: number) {
+      state.dataSource[index].done = !state.dataSource[index].done;
     },
     update(prevState: TodosState, payload) {
       return {
@@ -31,7 +31,7 @@ const todos = {
   },
   effects: {
     add(state: TodosState, todo: Todo, actions, globalActions) {
-      const dataSource = [].concat(state.dataSource);
+      const dataSource = ([] as any).concat(state.dataSource);
       dataSource.push(todo);
       globalActions.user.setTodos(dataSource.length);
       actions.update({
@@ -60,7 +60,7 @@ const todos = {
     },
     async remove(state: TodosState, index: number, actions, globalActions) {
       await delay(1000);
-      const dataSource = [].concat(state.dataSource);
+      const dataSource = ([] as any).concat(state.dataSource);
       dataSource.splice(index, 1);
 
       globalActions.user.setTodos(dataSource.length);

--- a/examples/todos/src/models/user.ts
+++ b/examples/todos/src/models/user.ts
@@ -9,8 +9,8 @@ const user = {
     auth: false,
   },
   reducers: {
-    setTodos(prevState, todos: number) {
-      prevState.todos = todos;
+    setTodos(state, todos: number) {
+      state.todos = todos;
     },
     update(prevState, payload) {
       return {

--- a/examples/todos/src/models/user.ts
+++ b/examples/todos/src/models/user.ts
@@ -10,7 +10,7 @@ const user = {
   },
   reducers: {
     setTodos(prevState, todos: number) {
-      return { ...prevState, todos };
+      prevState.todos = todos;
     },
     update(prevState, payload) {
       return {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "preset": "ts-jest"
   },
   "dependencies": {
+    "immer": "^6.0.1",
     "is-promise": "^2.1.0",
     "lodash.transform": "^4.6.0",
     "utility-types": "^3.10.0"

--- a/src/createModel.tsx
+++ b/src/createModel.tsx
@@ -2,7 +2,7 @@
 import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import isPromise from 'is-promise';
 import transform from 'lodash.transform';
-import produce from 'immer';
+import produce, { enableES5 } from 'immer';
 import { createContainer } from './createContainer';
 import {
   ReactSetState,
@@ -21,6 +21,8 @@ import {
   ModelValue,
   Options,
 } from './types';
+
+enableES5();
 
 const isDev = process.env.NODE_ENV !== 'production';
 

--- a/src/createModel.tsx
+++ b/src/createModel.tsx
@@ -159,12 +159,12 @@ export function createModel<C extends Config, K = string>(config: C, options?: O
         result[name] = (payload) => setState((prevState) =>
           !disableImmer && typeof prevState === 'object'
             ? produce(prevState, (draft) => {
-                const next = fn(draft, payload);
-                if (typeof next === 'object') {
-                  return next;
-                }
-              })
-            : fn(prevState, payload)
+              const next = fn(draft, payload);
+              if (typeof next === 'object') {
+                return next;
+              }
+            })
+            : fn(prevState, payload),
         );
       });
 

--- a/src/createModel.tsx
+++ b/src/createModel.tsx
@@ -43,7 +43,7 @@ export function createModel<C extends Config, K = string>(config: C, options?: O
     reducers = {},
   } = config;
   const mergedEffects = { ...defineActions, ...effects };
-  const disableImmer = options && options.disableImmer;
+  const immerable = !(options && options.disableImmer);
   let actions;
 
   if (Object.keys(defineActions).length > 0) {
@@ -159,7 +159,7 @@ export function createModel<C extends Config, K = string>(config: C, options?: O
 
       const setReducers = transform(reducers, (result, fn, name) => {
         result[name] = (payload) => setState((prevState) =>
-          !disableImmer && typeof prevState === 'object'
+          immerable && typeof prevState === 'object'
             ? produce(prevState, (draft) => {
               const next = fn(draft, payload);
               if (typeof next === 'object') {

--- a/src/createModel.tsx
+++ b/src/createModel.tsx
@@ -19,11 +19,12 @@ import {
   ModelEffectsState,
   SetFunctionsState,
   ModelValue,
+  Options,
 } from './types';
 
 const isDev = process.env.NODE_ENV !== 'production';
 
-export function createModel<C extends Config, K = string>(config: C, namespace?: K, modelsActions?): Model<C> {
+export function createModel<C extends Config, K = string>(config: C, options?: Options, namespace?: K, modelsActions?): Model<C> {
   type IModelState = ConfigPropTypeState<C>;
   type IModelConfigMergedEffects = ConfigMergedEffects<C>;
   type IModelConfigMergedEffectsKey = keyof IModelConfigMergedEffects;
@@ -40,6 +41,7 @@ export function createModel<C extends Config, K = string>(config: C, namespace?:
     reducers = {},
   } = config;
   const mergedEffects = { ...defineActions, ...effects };
+  const disableImmer = options && options.disableImmer;
   let actions;
 
   if (Object.keys(defineActions).length > 0) {
@@ -155,7 +157,7 @@ export function createModel<C extends Config, K = string>(config: C, namespace?:
 
       const setReducers = transform(reducers, (result, fn, name) => {
         result[name] = (payload) => setState((prevState) =>
-          typeof prevState === 'object'
+          !disableImmer && typeof prevState === 'object'
             ? produce(prevState, (draft) => {
                 const next = fn(draft, payload);
                 if (typeof next === 'object') {

--- a/src/createStore.tsx
+++ b/src/createStore.tsx
@@ -9,9 +9,10 @@ import {
   ModelActions,
   ModelEffectsState,
   UseModelValue,
+  Options,
 } from './types';
 
-export function createStore<C extends Configs>(configs: C) {
+export function createStore<C extends Configs>(configs: C, options?: Options) {
   function getModel<K extends keyof C>(namespace: K): Model<C[K]> {
     const model = models[namespace];
     if (!model) {
@@ -101,7 +102,7 @@ export function createStore<C extends Configs>(configs: C) {
 
   const modelsActions = {};
   const models: { [K in keyof C]?: Model<C[K]> } = transform(configs, (result, config, namespace) => {
-    result[namespace] = createModel(config, namespace, modelsActions);
+    result[namespace] = createModel(config, options, namespace, modelsActions);
   });
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,3 +147,7 @@ export type Model<C extends Config> =
   ]
   >;
 export type UseModelValue<C extends Config> = [ ConfigPropTypeState<C>, ModelActions<C> ];
+
+export interface Options {
+  disableImmer?: boolean;
+}


### PR DESCRIPTION
## 为什么？

- 确保在 reducer  内的 state 是不可变的，将使得 react 的[性能优化可保障](reactjs.org/docs/optimizing-performance.html#examples)；
- 当处理深层嵌套对象时，以 immutable （不可变）的方式更新它们令人费解。immer 帮助编写高可读性的代码，且不会失去 immutability （不可变性）带来的好处。

## 变化

### Before

```js
const model = {
  state: [],
  reducers: {
    add(prevState, payload) {
      return [...prevState, payload];
    }
  }
}
```

### After

```js
const model = {
  state: [],
  reducers: {
    add(state, payload) {
      state.push(payload);
    }
  }
}
```

## 向下兼容

- 开发者依然可以通过在 reducer 内返回对象的方式更新 state；
- 通过设置 disableImmer 不使用不可变数据。