### PR TITLE
Release 1.3.1

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -149,30 +149,6 @@ const user = {
 
 #### options
 
-- `initialState` (Object, optional, default=undefined)
-
-  Allows you to hydrate your store with initial state (for example state received from your server in a server rendering context).
-
-  ```jsx
-  import { createStore } from '@ice/store';
-
-  const models = {
-    todo: { state: {}, },
-    user: { state: {}, },
-  };
-
-  const initialState = {
-    todo: {
-      title: 'Foo',
-      done: true,
-    },
-    user: {
-      name: 'Alvin',
-      age: 18,
-    },
-  };
-  createStore(models, { initialState });
-  ```
 - `disableImmer` (boolean, optional, default=false)
 
   If you set this to true, then [immer](https://github.com/immerjs/immer) will be disabled, meaning you can no longer mutate state directly within actions and will instead have to return immutable state as in a standard reducer.
@@ -207,6 +183,38 @@ ReactDOM.render(
   </Provider>,
   rootEl
 ); 
+```
+
+Provider allows you to hydrate your store with initial state (for example state received from your server in a server rendering context).
+
+```jsx
+import { createStore } from '@ice/store';
+
+const models = {
+  todo: { state: {}, },
+  user: { state: {}, },
+};
+
+const store = createStore(models);
+const { Provider } = store;
+
+const initialState = {
+  todo: {
+    title: 'Foo',
+    done: true,
+  },
+  user: {
+    name: 'Alvin',
+    age: 18,
+  },
+};
+function App() {
+  return (
+    <Provider initialState={initialState}>
+      <App />
+    </Provider>
+  );
+}
 ```
 
 #### useModel

--- a/docs/api.zh-CN.md
+++ b/docs/api.zh-CN.md
@@ -149,30 +149,6 @@ const user = {
 
 #### options
 
-- `initialState` (对象, 可选, 默认值=undefined)
-
-  允许您声明初始状态（可以用在诸如服务端渲染等场景）。
-
-  ```jsx
-  import { createStore } from '@ice/store';
-
-  const models = {
-    todo: { state: {}, },
-    user: { state: {}, },
-  };
-
-  const initialState = {
-    todo: {
-      title: 'Foo',
-      done: true,
-    },
-    user: {
-      name: 'Alvin',
-      age: 18,
-    },
-  };
-  createStore(models, { initialState });
-  ```
 - `disableImmer` (布尔值, 可选, 默认值=false)
 
   如果您将其设置为true，那么 immer 将被禁用，这意味着您不能再在 reducers 中直接改变状态，而是必须返回新的状态。
@@ -207,6 +183,38 @@ ReactDOM.render(
   </Provider>,
   rootEl
 ); 
+```
+
+允许您声明初始状态（可以用在诸如服务端渲染等场景）。
+
+```jsx
+import { createStore } from '@ice/store';
+
+const models = {
+  todo: { state: {}, },
+  user: { state: {}, },
+};
+
+const store = createStore(models);
+const { Provider } = store;
+
+const initialState = {
+  todo: {
+    title: 'Foo',
+    done: true,
+  },
+  user: {
+    name: 'Alvin',
+    age: 18,
+  },
+};
+function App() {
+  return (
+    <Provider initialState={initialState}>
+      <App />
+    </Provider>
+  );
+}
 ```
 
 #### useModel

--- a/docs/upgrade-guidelines.md
+++ b/docs/upgrade-guidelines.md
@@ -34,15 +34,20 @@ function App() {
 #### 1.3.0
 
 ```js
-import { createStore } from '@ice/store';
-import * as models from './models';
+import store from './store';
+const { Provider } = store;
 
 const initialState = {
   foo: {
   },
 };
-
-export default createStore(models, { initialState });
+function App() {
+  return (
+    <Provider initialState={initialState}>
+      <Todos />
+    </Provider>
+  );
+}
 ```
 
 ### Define Model Effects

--- a/docs/upgrade-guidelines.zh-CN.md
+++ b/docs/upgrade-guidelines.zh-CN.md
@@ -35,15 +35,20 @@ function App() {
 #### 1.3.0
 
 ```js
-import { createStore } from '@ice/store';
-import * as models from './models';
+import store from './store';
+const { Provider } = store;
 
 const initialState = {
   foo: {
   },
 };
-
-export default createStore(models, { initialState });
+function App() {
+  return (
+    <Provider initialState={initialState}>
+      <Todos />
+    </Provider>
+  );
+}
 ```
 
 ### Define Model Effects

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/store",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Simple and friendly state for React",
   "main": "lib/index.js",
   "files": [

--- a/src/actionTypes.ts
+++ b/src/actionTypes.ts
@@ -1,0 +1,12 @@
+const randomString = () =>
+  Math.random()
+    .toString(36)
+    .substring(7)
+    .split('')
+    .join('.');
+
+const ActionTypes = {
+  SET_STATE: `@@icestore/SET_STATE${/* #__PURE__ */ randomString()}`,
+};
+
+export default ActionTypes;

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,6 @@ export const createStore = <M extends T.Models, C extends T.CreateStoreConfig<M>
     disableImmer,
     disableLoading,
     disableError,
-    initialState,
     plugins = [],
     redux = {},
   } = initConfig || {};
@@ -85,7 +84,6 @@ export const createStore = <M extends T.Models, C extends T.CreateStoreConfig<M>
     plugins,
     redux: {
       ...redux,
-      initialState,
       middlewares,
     },
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,19 +13,6 @@ import createErrorPlugin from './plugins/error';
 import { convertEffects, convertActions } from './utils/converter';
 import appendReducers from './utils/appendReducers';
 
-/**
- * global createModel
- *
- * creates a model for the given object
- * this is for autocomplete purposes only
- * returns the same object that was received as argument
- */
-export function createModel<S = any, M extends T.ModelConfig<S> = any>(
-  model: M,
-) {
-  return model;
-}
-
 // incrementer used to provide a store name if none exists
 let count = 0;
 
@@ -35,7 +22,7 @@ let count = 0;
  * generates a Icestore with a set configuration
  * @param config
  */
-export const init = <M extends T.Models>(initConfig: T.InitConfig<M> = {}): T.Icestore<M> => {
+const init = <M extends T.Models>(initConfig: T.InitConfig<M> = {}): T.Icestore<M> => {
   const name = initConfig.name || count.toString();
   count += 1;
   const config: T.Config = mergeConfig({ ...initConfig, name });

--- a/src/plugins/effectsStateApis.tsx
+++ b/src/plugins/effectsStateApis.tsx
@@ -28,6 +28,9 @@ export default (): T.Plugin => {
         return states;
       };
 
+      /**
+       * @deprecated use `useModelEffectsState` instead
+       */
       function useModelActionsState(name) {
         if (!warnedUseModelActionsState) {
           warnedUseModelActionsState = true;
@@ -62,8 +65,6 @@ export default (): T.Plugin => {
       return {
         useModelEffectsState,
         withModelEffectsState: createWithModelEffectsState(),
-
-        // @deprecated
         useModelActionsState,
         withModelActionsState: createWithModelEffectsState(actionsSuffix),
       };

--- a/src/plugins/modelApis.tsx
+++ b/src/plugins/modelApis.tsx
@@ -27,6 +27,9 @@ export default (): T.Plugin => {
         return dispatch[name];
       }
 
+      /**
+       * @deprecated use `useModelDispatchers` instead.
+       */
       function useModelActions(name: string) {
         if (!warnedUseModelActions) {
           warnedUseModelActions = true;
@@ -89,6 +92,7 @@ export default (): T.Plugin => {
         useModel,
         useModelState,
         useModelDispatchers,
+        useModelActions,
 
         // real time
         getModel,
@@ -98,9 +102,6 @@ export default (): T.Plugin => {
         // Class component support
         withModel,
         withModelDispatchers: createWithModelDispatchers(),
-
-        // @deprecated
-        useModelActions,
         withModelActions: createWithModelDispatchers(actionsSuffix),
       };
     },

--- a/src/plugins/provider.tsx
+++ b/src/plugins/provider.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import * as T from '../types';
 import warning from '../utils/warning';
+import actionTypes from '../actionTypes';
+
+const { SET_STATE } = actionTypes;
 
 interface ProviderConfig {
   context: React.Context<null>;
@@ -16,8 +19,8 @@ export default ({ context }: ProviderConfig): T.Plugin => {
           warning('`initialStates` API has been detected, please use `createStore(model, { initialState })` instead. \n\n\n Visit https://github.com/ice-lab/icestore/blob/master/docs/upgrade-guidelines.md#initialstate to learn about how to upgrade.');
           Object.keys(initialStates).forEach(name => {
             const initialState = initialStates[name];
-            if (initialState && store.dispatch[name].setState) {
-              store.dispatch[name].setState(initialState);
+            if (initialState && store.dispatch[name][SET_STATE]) {
+              store.dispatch[name][SET_STATE](initialState);
             }
           });
         }

--- a/src/plugins/provider.tsx
+++ b/src/plugins/provider.tsx
@@ -13,14 +13,17 @@ interface ProviderConfig {
 export default ({ context }: ProviderConfig): T.Plugin => {
   return {
     onStoreCreated(store: any) {
-      const Provider = function(props: { children; initialStates? }) {
-        const { children, initialStates } = props;
-        if (initialStates) {
-          warning('`initialStates` API has been detected, please use `createStore(model, { initialState })` instead. \n\n\n Visit https://github.com/ice-lab/icestore/blob/master/docs/upgrade-guidelines.md#initialstate to learn about how to upgrade.');
-          Object.keys(initialStates).forEach(name => {
-            const initialState = initialStates[name];
-            if (initialState && store.dispatch[name][SET_STATE]) {
-              store.dispatch[name][SET_STATE](initialState);
+      const Provider = function(props: { children; initialStates?; initialState?; }) {
+        const { children, initialStates, initialState } = props;
+        const states = initialState || initialStates;
+        if (states) {
+          if (initialStates) {
+            warning('`initialStates` API has been detected, please use `initialState` instead. \n\n\n Visit https://github.com/ice-lab/icestore/blob/master/docs/upgrade-guidelines.md#initialstate to learn about how to upgrade.');
+          }
+          Object.keys(states).forEach(name => {
+            const state = states[name];
+            if (state && store.dispatch[name][SET_STATE]) {
+              store.dispatch[name][SET_STATE](state);
             }
           });
         }

--- a/src/plugins/provider.tsx
+++ b/src/plugins/provider.tsx
@@ -13,7 +13,7 @@ interface ProviderConfig {
 export default ({ context }: ProviderConfig): T.Plugin => {
   return {
     onStoreCreated(store: any) {
-      const Provider = function(props: { children; initialStates?; initialState?; }) {
+      const Provider = function(props: { children; initialStates?; initialState? }) {
         const { children, initialStates, initialState } = props;
         const states = initialState || initialStates;
         if (states) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -221,8 +221,18 @@ export interface ModelPluginAPI<M extends Models = Models> {
   withModelActions: WithModelDispatchers<M>;
 }
 
+export interface ProviderProps {
+  children: any;
+  initialState?: any;
+
+  /**
+   * @deprecated use `initialState` instead.
+   */
+  initialStates?: any;
+}
+
 export interface ProviderPluginAPI {
-  Provider: (props: { children: any; initialStates?: any }) => JSX.Element;
+  Provider: (props: ProviderProps) => JSX.Element;
 }
 
 export type PresetIcestore<
@@ -285,7 +295,11 @@ export interface ModelConfig<S = any, SS = S> {
   | ModelEffects<any>
   | ((dispatch: IcestoreDispatch) => ModelEffects<any>)
   | ConfigEffects;
-  actions?: ConfigActions<S>; // @deprecated
+
+  /**
+   * @deprecated use `effects` instead.
+   */
+  actions?: ConfigActions<S>;
 }
 
 export interface PluginFactory extends Plugin {
@@ -385,29 +399,79 @@ declare global {
   }
 }
 
-/** @deprecated */
+/**
+ * @deprecated
+ */
 export type ConfigAction<S = any> = (prevState: S, payload?: any, actions?: any, globalActions?: any) => S | Promise<S>;
+/**
+ * @deprecated
+ */
 export type ConfigEffect<S = any> = (state: S, payload?: any, actions?: any, globalActions?: any) => void | Promise<void>;
+/**
+ * @deprecated
+ */
 export type ConfigReducer<S = any> = (state: S, payload?: any,) => S;
+/**
+ * @deprecated
+ */
 export interface ConfigEffects<S = any> {
   [name: string]: ConfigEffect<S>;
 }
+/**
+ * @deprecated
+ */
 export interface ConfigReducers<S = any> {
   [name: string]: ConfigReducer<S>;
 }
+/**
+ * @deprecated
+ */
 export interface ConfigActions<S = any> {
   [name: string]: ConfigAction<S>;
 }
+/**
+ * @deprecated
+ */
 export type Actions<A extends ConfigEffects> = {
   [K in keyof A]: (payload?: Parameters<A[K]>[1]) => void;
 }
+/**
+ * @deprecated
+ */
 export type ConfigPropTypeState<C extends ModelConfig> = PropType<C, 'state'>;
+/**
+ * @deprecated
+ */
 export type ConfigPropTypeActions<C extends ModelConfig> = PropType<C, 'actions'>;
+/**
+ * @deprecated
+ */
 export type ConfigPropTypeEffects<C extends ModelConfig> = PropType<C, 'effects'>;
+/**
+ * @deprecated
+ */
 export type ConfigPropTypeReducers<C extends ModelConfig> = PropType<C, 'reducers'>;
+/**
+ * @deprecated
+ */
 export type ConfigMergedEffects<C extends ModelConfig> = ConfigPropTypeActions<C> & ConfigPropTypeEffects<C>;
-export type OldModelEffects<C extends ModelConfig> = Actions<ConfigMergedEffects<C>>;;
+/**
+ * @deprecated
+ */
+export type OldModelEffects<C extends ModelConfig> = Actions<ConfigMergedEffects<C>>;
+/**
+ * @deprecated
+ */
 export type ModelActions<C extends ModelConfig> = Actions<ConfigPropTypeReducers<C> & ConfigPropTypeEffects<C>>;
+/**
+ * @deprecated
+ */
 export type ModelEffectsState<C extends ModelConfig> = ExtractIModelEffectsStateFromModelConfig<C>;
+/**
+ * @deprecated
+ */
 export type ModelValue<C extends ModelConfig> = [ ConfigPropTypeState<C>, ModelActions<C>, ModelEffectsState<C> ];
+/**
+ * @deprecated
+ */
 export type UseModelValue<C extends ModelConfig> = [ ConfigPropTypeState<C>, ModelActions<C> ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,8 +185,16 @@ export interface WithModelEffectsState<M extends Models> {
 
 export interface EffectsStatePluginAPI<M extends Models = Models> {
   useModelEffectsState: UseModelEffectsState<M>;
+
+  /**
+   * @deprecated use `useModelEffectsState` instead
+   */
   useModelActionsState: UseModelEffectsState<M>;
   withModelEffectsState: WithModelEffectsState<M>;
+
+  /**
+   * @deprecated use `withModelEffectsState` instead
+   */
   withModelActionsState: WithModelEffectsState<M>;
 }
 
@@ -207,6 +215,10 @@ export interface ModelPluginAPI<M extends Models = Models> {
   useModel<K extends keyof M>(name: K): ExtractIModelFromModelConfig<M[K]>;
   useModelState<K extends keyof M>(name: K): ExtractIModelStateFromModelConfig<M[K]>;
   useModelDispatchers: UseModelDispatchers<M>;
+
+  /**
+   * @deprecated use `useModelDispatchers` instead.
+   */
   useModelActions: UseModelDispatchers<M>;
   getModel<K extends keyof M>(name: K): ExtractIModelFromModelConfig<M[K]>;
   getModelState<K extends keyof M>(name: K): ExtractIModelStateFromModelConfig<M[K]>;
@@ -218,6 +230,10 @@ export interface ModelPluginAPI<M extends Models = Models> {
   <R extends ReturnType<F>, P extends R>(Component: React.ComponentType<P>) =>
   (props: Optionalize<P, R>) => React.ReactElement;
   withModelDispatchers: WithModelDispatchers<M>;
+
+  /**
+   * @deprecated use `withModelDispatchers` instead.
+   */
   withModelActions: WithModelDispatchers<M>;
 }
 
@@ -436,7 +452,7 @@ export type Actions<A extends ConfigEffects> = {
   [K in keyof A]: (payload?: Parameters<A[K]>[1]) => void;
 }
 /**
- * @deprecated
+ * @deprecated use `ExtractIModelStateFromModelConfig` instead
  */
 export type ConfigPropTypeState<C extends ModelConfig> = PropType<C, 'state'>;
 /**
@@ -444,11 +460,11 @@ export type ConfigPropTypeState<C extends ModelConfig> = PropType<C, 'state'>;
  */
 export type ConfigPropTypeActions<C extends ModelConfig> = PropType<C, 'actions'>;
 /**
- * @deprecated
+ * @deprecated use `ExtractIModelEffectsFromModelConfig` instead
  */
 export type ConfigPropTypeEffects<C extends ModelConfig> = PropType<C, 'effects'>;
 /**
- * @deprecated
+ * @deprecated use `ExtractIModelReducersFromModelConfig` instead
  */
 export type ConfigPropTypeReducers<C extends ModelConfig> = PropType<C, 'reducers'>;
 /**
@@ -456,15 +472,15 @@ export type ConfigPropTypeReducers<C extends ModelConfig> = PropType<C, 'reducer
  */
 export type ConfigMergedEffects<C extends ModelConfig> = ConfigPropTypeActions<C> & ConfigPropTypeEffects<C>;
 /**
- * @deprecated
+ * @deprecated use `ExtractIModelDispatchersFromEffects` instead
  */
 export type OldModelEffects<C extends ModelConfig> = Actions<ConfigMergedEffects<C>>;
 /**
- * @deprecated
+ * @deprecated use `ExtractIModelDispatchersFromModelConfig` instead
  */
 export type ModelActions<C extends ModelConfig> = Actions<ConfigPropTypeReducers<C> & ConfigPropTypeEffects<C>>;
 /**
- * @deprecated
+ * @deprecated use `ExtractIModelEffectsStateFromModelConfig` instead
  */
 export type ModelEffectsState<C extends ModelConfig> = ExtractIModelEffectsStateFromModelConfig<C>;
 /**
@@ -472,6 +488,6 @@ export type ModelEffectsState<C extends ModelConfig> = ExtractIModelEffectsState
  */
 export type ModelValue<C extends ModelConfig> = [ ConfigPropTypeState<C>, ModelActions<C>, ModelEffectsState<C> ];
 /**
- * @deprecated
+ * @deprecated use `ExtractIModelFromModelConfig` instead
  */
 export type UseModelValue<C extends ModelConfig> = [ ConfigPropTypeState<C>, ModelActions<C> ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -374,7 +374,6 @@ export interface PrsetConfig {
   disableImmer?: boolean;
   disableLoading?: boolean;
   disableError?: boolean;
-  initialState?: any;
 }
 
 export type CreateStoreConfig<M extends Models = Models> = InitConfig<M> & PrsetConfig;

--- a/src/utils/appendReducers.ts
+++ b/src/utils/appendReducers.ts
@@ -1,3 +1,7 @@
+import actionTypes from '../actionTypes';
+
+const { SET_STATE } = actionTypes;
+
 export default function(originModels: any) {
   const models = {};
   Object.keys(originModels).forEach(function(name) {
@@ -11,8 +15,8 @@ export default function(originModels: any) {
         ...payload,
       });
     }
-    if (!model.reducers.setState) {
-      model.reducers.setState = (state, payload) => payload;
+    if (!model.reducers[SET_STATE]) {
+      model.reducers[SET_STATE] = (state, payload) => payload;
     }
     models[name] = model;
   });

--- a/src/utils/converter.ts
+++ b/src/utils/converter.ts
@@ -65,7 +65,9 @@ export function convertActions(originModels: any) {
               dispatch[name],
               dispatch,
             );
-            dispatch[name][SET_STATE](result);
+            if (dispatch[name][SET_STATE]) {
+              dispatch[name][SET_STATE](result);
+            }
           };
         });
         return effects;

--- a/src/utils/converter.ts
+++ b/src/utils/converter.ts
@@ -1,5 +1,8 @@
 import isFunction from 'lodash.isfunction';
 import warning from './warning';
+import actionTypes from '../actionTypes';
+
+const { SET_STATE } = actionTypes;
 
 /**
  * convertEffects
@@ -43,7 +46,6 @@ export function convertEffects(originModels: any) {
  */
 export function convertActions(originModels: any) {
   const models = {};
-  const setState = '__actionSetState__';
   Object.keys(originModels).forEach(function(name) {
     const model = originModels[name];
     const actions = model.actions;
@@ -52,7 +54,6 @@ export function convertActions(originModels: any) {
       if (!model.reducers) {
         model.reducers = {};
       }
-      model.reducers[setState] = (state, payload) => payload;
       model.effects = function(dispatch: any) {
         const effects = {};
         Object.keys(actions).forEach(function(key) {
@@ -64,7 +65,7 @@ export function convertActions(originModels: any) {
               dispatch[name],
               dispatch,
             );
-            dispatch[name][setState](result);
+            dispatch[name][SET_STATE](result);
           };
         });
         return effects;


### PR DESCRIPTION
- 修复类型问题：https://github.com/ice-lab/icestore/pull/83
- 为过期的方法和工具类型添加 `@deprecated` ，以供在 VS Code 中获得提醒；
- 模型初始化数据通过 Provider 的 initialState 字段传递。