### PR TITLE
feat: throw error of not found model

### DIFF
--- a/src/plugins/modelApis.tsx
+++ b/src/plugins/modelApis.tsx
@@ -20,11 +20,18 @@ export default (): T.Plugin => {
         return [state, dispatchers];
       }
       function useModelState(name: string) {
-        return store.useSelector(state => state[name]);
+        const selector = store.useSelector(state => state[name]);
+        if (selector) {
+          return selector;
+        }
+        throw new Error(`Not found model by namespace: ${name}.`);
       }
       function useModelDispatchers(name: string) {
         const dispatch = store.useDispatch();
-        return dispatch[name];
+        if (dispatch[name]) {
+          return dispatch[name];
+        }
+        throw new Error(`Not found model by namespace: ${name}.`);
       }
 
       /**
@@ -107,4 +114,3 @@ export default (): T.Plugin => {
     },
   };
 };
-


### PR DESCRIPTION
## 问题描述
当用户使用`useModel()`、`useModelState()`、`useModelDispatchers()`等api时传入不存在的model，iceStore应抛出异常，让用户及时发现追踪错误问题。
## 解决
在`useModelState` 和 `useModelDispatchers` 中分别增加条件判断，对异常情况`throw error`