### PR TITLE
fix: fix can't get correct state

### DIFF
--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@ice/store": "^1.3.3",
+    "@ice/store": "^1.3.4",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@ice/store": "^1.3.3",
+    "@ice/store": "^1.3.4",
     "lodash": "^4.17.15",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/store",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Simple and friendly state for React",
   "main": "lib/index.js",
   "files": [

--- a/src/plugins/modelApis.tsx
+++ b/src/plugins/modelApis.tsx
@@ -21,14 +21,14 @@ export default (): T.Plugin => {
       }
       function useModelState(name: string) {
         const selector = store.useSelector(state => state[name]);
-        if (selector) {
+        if (selector !== undefined) {
           return selector;
         }
         throw new Error(`Not found model by namespace: ${name}.`);
       }
       function useModelDispatchers(name: string) {
         const dispatch = store.useDispatch();
-        if (dispatch[name]) {
+        if (dispatch[name] !== undefined) {
           return dispatch[name];
         }
         throw new Error(`Not found model by namespace: ${name}.`);

--- a/src/plugins/modelApis.tsx
+++ b/src/plugins/modelApis.tsx
@@ -21,14 +21,14 @@ export default (): T.Plugin => {
       }
       function useModelState(name: string) {
         const selector = store.useSelector(state => state[name]);
-        if (selector !== undefined) {
+        if (typeof selector !== "undefined") {
           return selector;
         }
         throw new Error(`Not found model by namespace: ${name}.`);
       }
       function useModelDispatchers(name: string) {
         const dispatch = store.useDispatch();
-        if (dispatch[name] !== undefined) {
+        if (dispatch[name]) {
           return dispatch[name];
         }
         throw new Error(`Not found model by namespace: ${name}.`);


### PR DESCRIPTION
## 问题描述
当 `model` 中的 `state` 初始值为0时，通过 `useModelState` API 获取 `state` 报错。

原因为
```javascript
 const selector = store.useSelector(state => state[name]);
        if (selector) { // 当这里的selector === 0 statement为faslse, 无法正常返回 modelstate
          return selector;
        }
```

## fix
```javascript
   if (selector !== undefined) { 
          return selector;
   }
```