### PR TITLE
fix: add meta type in ModelEffects

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -276,7 +276,8 @@ export interface ModelEffects<S> {
   [key: string]: (
     this: { [key: string]: (payload?: any, meta?: any) => Action<any, any> },
     payload: any,
-    rootState: S
+    rootState: S,
+    meta: any
   ) => void;
 }
 


### PR DESCRIPTION
## 问题描述
当在 effect 中使用 meta 变量时，ts 类型推导有问题
![image](https://user-images.githubusercontent.com/44047106/79545194-dee85400-80c2-11ea-8b10-fc9bce5c6948.png)
![image](https://user-images.githubusercontent.com/44047106/79545265-fa535f00-80c2-11ea-82bd-81b5716cbcb4.png)

## 解决
在 ModelEffects 中增加 meta 类型