### PR TITLE
fix: model reducer return type

### DIFF
--- a/examples/classComponent/package.json
+++ b/examples/classComponent/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@ice/store": "^1.3.4",
+    "@ice/store": "^2.0.0",
     "react-dom": "^16.8.6"
   },
   "devDependencies": {

--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@ice/store": "^1.3.4",
+    "@ice/store": "^2.0.0",
     "react-app-polyfill": "^1.0.6",
     "react-dom": "^16.8.6"
   },

--- a/examples/counter/src/index.tsx
+++ b/examples/counter/src/index.tsx
@@ -4,7 +4,7 @@ import { createStore, createModel } from '@ice/store';
 import 'react-app-polyfill/ie11';
 import 'react-app-polyfill/stable';
 
-const delay = (time: number) => new Promise((resolve) => setTimeout(() => resolve(0), time));
+const delay = (time: number) => new Promise<void>((resolve) => setTimeout(() => resolve(), time));
 
 // 1️⃣ Use createModel function to create a model to define your store
 const counter = createModel({

--- a/examples/counter/src/index.tsx
+++ b/examples/counter/src/index.tsx
@@ -4,7 +4,7 @@ import { createStore, createModel } from '@ice/store';
 import 'react-app-polyfill/ie11';
 import 'react-app-polyfill/stable';
 
-const delay = (time) => new Promise((resolve) => setTimeout(() => resolve(), time));
+const delay = (time: number) => new Promise((resolve) => setTimeout(() => resolve(0), time));
 
 // 1️⃣ Use createModel function to create a model to define your store
 const counter = createModel({
@@ -12,7 +12,9 @@ const counter = createModel({
     count: 0,
   },
   reducers: {
-    increment: (prevState) => ({ count: prevState.count + 1 }),
+    increment: (prevState) => {
+      prevState.count++;
+    },
     decrement: (prevState, payload: number) => ({ count: prevState.count - payload }),
   },
   effects: () => ({
@@ -42,7 +44,7 @@ function Counter() {
     <div>
       <span>{count}</span>
       <button type="button" onClick={increment}>+</button>
-      <button type="button" onClick={asyncDecrement}>-</button>
+      <button type="button" onClick={() => asyncDecrement(1)}>-</button>
     </div>
   );
 }

--- a/examples/migration-redux-1/package.json
+++ b/examples/migration-redux-1/package.json
@@ -4,7 +4,7 @@
   "description": "Using icestore with Redux only.",
   "private": true,
   "dependencies": {
-    "@ice/store": "^1.4.0",
+    "@ice/store": "^2.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-redux": "^7.2.0"

--- a/examples/migration-redux-2/package.json
+++ b/examples/migration-redux-2/package.json
@@ -4,7 +4,7 @@
   "description": "Using icestore with Redux & icestore.",
   "private": true,
   "dependencies": {
-    "@ice/store": "^1.4.0",
+    "@ice/store": "^2.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-redux": "^7.2.0"

--- a/examples/migration-redux-3/package.json
+++ b/examples/migration-redux-3/package.json
@@ -4,7 +4,7 @@
   "description": "Using icestore with react-redux only.",
   "private": true,
   "dependencies": {
-    "@ice/store": "^1.4.0",
+    "@ice/store": "^2.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-redux": "^7.2.0"

--- a/examples/migration-redux-4/package.json
+++ b/examples/migration-redux-4/package.json
@@ -4,7 +4,7 @@
   "description": "Using icestore with react-redux & icestore.",
   "private": true,
   "dependencies": {
-    "@ice/store": "^1.4.0",
+    "@ice/store": "^2.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-redux": "^7.2.0"

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@ice/store": "^1.4.0",
+    "@ice/store": "^2.0.0",
     "lodash": "^4.17.15",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/examples/withModel/package.json
+++ b/examples/withModel/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@ice/store": "^1.4.0",
+    "@ice/store": "^2.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -329,7 +329,7 @@ export interface Action<P = any, M = any> {
 }
 
 export interface ModelReducers<S = any> {
-  [key: string]: (state: S, payload: any, meta?: any) => S;
+  [key: string]: (state: S, payload: any, meta?: any) => S | void;
 }
 
 export interface ModelEffects<S> {

--- a/tests/helpers/createHook.tsx
+++ b/tests/helpers/createHook.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as rhl from "@testing-library/react-hooks";
 
-function createHook(Provider: React.ComponentType<any>, callback: (...args) => any, namespace: string, initialStates?: any) {
+function createHook(Provider: React.ComponentType<any>, callback: (...args: any[]) => any, namespace: string, initialStates?: any) {
   return rhl.renderHook<React.PropsWithChildren<Record<string, any>>, any>(() => callback(namespace), {
     wrapper: (props) => (
       <Provider {...props} initialStates={initialStates}>

--- a/tests/helpers/createHook.tsx
+++ b/tests/helpers/createHook.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import * as rhl from "@testing-library/react-hooks";
 
-function createHook(Provider, callback, namespace, initialStates?: any) {
-  return rhl.renderHook(() => callback(namespace), {
+function createHook(Provider: React.ComponentType<any>, callback: (...args) => any, namespace: string, initialStates?: any) {
+  return rhl.renderHook<React.PropsWithChildren<Record<string, any>>, any>(() => callback(namespace), {
     wrapper: (props) => (
       <Provider {...props} initialStates={initialStates}>
         {props.children}


### PR DESCRIPTION
解决使用 immer 更改 state 时 reducer 方法返回值错误的问题。如果使用 immer 更改 state，不需要返回任何值，比如：

```ts
const model = {
  state: {
    count: 1
  },
  reducers: {
     increment: (prevState) => {
      prevState.count++;
     }
  }
}

```