### PR TITLE
chore: update peeerDependencies version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "redux-thunk": "^2.3.0"
   },
   "peerDependencies": {
-    "react": "^16.8.3 || ^17 || ^18"
+    "react": "^16.8 || ^17 || ^18"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "redux-thunk": "^2.3.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": "^16.8.3 || ^17 || ^18"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "redux-thunk": "^2.3.0"
   },
   "peerDependencies": {
-    "react": "^16.8.3 || ^17"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",


### PR DESCRIPTION
peerDependencies react 版本在 16.8.0 以上即可，避免项目中依赖 react@18.0.0 时出现 peerDependencies 版本不兼容问题